### PR TITLE
Adjust window SDK-2243

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,49 @@
-This script is the python-sdk-sample for frame detector.
+# Sample Python App for Affdex SDK #
 
-Steps to install the app:
+This script is the python-sdk-sample for the frame detector demo.
 
-1. Make sure you have affvisionpy
+## Steps to install the app: ##
 
-2. cd into the directory containing the setup.py script and run: sudo python3 setup.py install.
+1. Make sure you have **affvisionpy**
 
-   Alternative to step 2 : cd into the directory having the requirements.txt file and run "pip3 install -r requirements.txt"
+2. **cd** into the directory containing the setup.py script and run: **sudo python3 setup.py install**.
+
+    Alternative to step 2 : **cd** into the directory having the requirements.txt file and run **pip3 install -r requirements.txt**
 
 
-Steps to run the script:
+## Steps to run the script: ##
 
 1. usage:
 
         python3 affvisionpy-sample.py [-h] -d DATA [-v VIDEO] [-n NUM_FACES] [-c [CAMERA]] [-o OUTPUT] [-f FILE] [-r WIDTH HEIGHT]
 
         required arguments:
-
             -d DATA, --data DATA  path to directory containing the models
-
-
+        
         optional arguments:
 
-          -h, --help            show this help message and exit
+          -h, --help    show this help message and exit
 
-          -v VIDEO, --video VIDEO
-                        path to input video file
+          -v VIDEO, --video VIDEO    path to input video file
+                       
 
-          -n NUM_FACES, --num_faces NUM_FACES
-                        number of faces to identify in the frame
+          -n NUM_FACES, --num_faces NUM_FACES    number of faces to identify in the frame
+                        
 
-          -o OUTPUT, --output OUTPUT
-                        enable this parameter to save the output video in a video file of your choice
+          -o OUTPUT, --output OUTPUT    enable this parameter to save the output video in a AVI file of your choice
+                        
 
-          -f FILE, --file FILE
-                        enable this parameter to save the output metrics in a csv file of your choice
+          -f FILE, --file FILE    enable this parameter to save the output metrics in a CSV file of your choice
+                        
 
-          -c [CAMERA], --camera [CAMERA]
-                        enable this parameter take input from the webcam and provide a camera id for the webcam
+          -c [CAMERA], --camera [CAMERA]    enable this parameter to take input from the webcam and provide a camera id for the webcam
+                        
 
-          -r --resolution WIDTH HEIGHT set the resolution in pixels (width, height) for the webcam. Defaults to 1280 x 720 resolution.
-
-        Note: if only data argument is supplied, the script defaults the run to a webcam and 1 face detection, with the output written to "default.csv"
-        displaying frames at default size of 1280 x 720. Only certain standard frame sizes are supported. For any unsupported frame sizes, the webcam frame size defaults
-        to 1280 x 720. If any other configuration is required, it can be done using optional arguments.
+          -r --resolution WIDTH HEIGHT   set the resolution in pixels (width, height) for the webcam. Defaults to 1280 x 720 resolution.
+          
+    **Note**: if only the data argument is supplied, the script defaults the run to a webcam and 1 face detection, with the output written to "default.csv"
+    displaying frames at default size of 1280 x 720. Only certain standard frame sizes are supported. For any unsupported frame sizes, the webcam frame size defaults
+    to 1280 x 720. If any other configuration is required, it can be done using optional arguments.
 
 
 
@@ -51,31 +51,38 @@ Steps to run the script:
 
 3. By default the num of faces detected by the script is 1.
 
-4.
+4. Example Usages:
 
     i. Command to run the script with webcam:
 
             python3 affvisionpy-sample.py -d <path/to/data/directory> -c <camera_id> -n <num_of_faces_to_detect>
-
-            Note: If the camera id is not supplied, by default the camera_id 0 is taken
+            
+       **Note:** If the camera id is not supplied, by default the camera_id is set to 0.
 
     ii. Command to run the script with a video file:
 
             python3 affvisionpy-sample.py -d <path/to/data/directory> -n <num_of_faces_to_detect> -v </path/to/video/file>
 
-            A csv file is written with the metrics. By default the csv file will be named "default.csv".
+    
+    iii. Command to run the script with a webcam and save the CSV file to a filename of your choice:
+    
+         python3 affvisionpy-sample.py -d <path/to/data/directory> -c <camera_id> -n <num_of_faces_to_detect> -f <filename> 
+    
+    iv. Command to run the script with a video file and save output video AVI file to a filename of your choice: 
+    
+         python3 affvisionpy-sample.py -d <path/to/data/directory> -n <num_of_faces_to_detect> -v </path/to/video/file> -o <filename>
+    
+    v. Command to run the script with a webcam and save the CSV file and output video AVI file to filenames of your choice:
+    
+        python3 affvisionpy-sample.py -d <path/to/data/directory> -n <num_of_faces_to_detect> -v </path/to/video/file> -o <filename> -f <filename>
 
-            The script displays real-time metrics on the screen for both video and webcam options.
 
-            To get the output metrics in a file of your choice, give the name of the file with -f on the command line.
+## Additional Notes ##
 
-            To get the output video, use the option -o along with the output file name.
+5.  For both video and webcam options, a CSV file is written with the metrics. By default, the CSV file will be named "default.csv".
 
+6.  For both video and webcam options, the script displays real-time metrics on the screen.
 
-5. For both video and webcam options, a csv file is written with the metrics. By default the csv file will be named "default.csv".
+7.  To get the output metrics in a file of your choice, give the name of the file with -f on the command line.
 
-6. When a webcam is used as an input, the script displays real-time metrics on the screen.
-
-7. To get the output metrics in a file of your choice, give the name of the file with -f on the command line.
-
-8. To get the output video, use the option -o along with the output file name.
+8.  To get the output video, use the option -o along with the output file name.

--- a/README.md
+++ b/README.md
@@ -39,11 +39,9 @@ Steps to run the script:
           -c [CAMERA], --camera [CAMERA]
                         enable this parameter take input from the webcam and provide a camera id for the webcam
 
-          -x --no-save  set this flag to disable outputting individual frame files.
-
           -r --resolution WIDTH HEIGHT set the resolution in pixels (width, height) for the webcam. Defaults to 1280 x 720 resolution.
 
-        Note: if only data argument is supplied, the script defaults the run to a webcam and 1 face detection, with the output written to "output.csv" and "output.avi"
+        Note: if only data argument is supplied, the script defaults the run to a webcam and 1 face detection, with the output written to "default.csv"
         displaying frames at default size of 1280 x 720. Only certain standard frame sizes are supported. For any unsupported frame sizes, the webcam frame size defaults
         to 1280 x 720. If any other configuration is required, it can be done using optional arguments.
 
@@ -65,16 +63,16 @@ Steps to run the script:
 
             python3 affvisionpy-sample.py -d <path/to/data/directory> -n <num_of_faces_to_detect> -v </path/to/video/file>
 
-            When a video file is provided as an input, a csv file is written with the metrics. By default the csv file will be named as the name of the video file.
+            A csv file is written with the metrics. By default the csv file will be named "default.csv".
 
-            When a webcam is used as an input, the script displays real-time metrics on the screen.
+            The script displays real-time metrics on the screen for both video and webcam options.
 
             To get the output metrics in a file of your choice, give the name of the file with -f on the command line.
 
             To get the output video, use the option -o along with the output file name.
 
 
-5. When a video file is provided as an input, a csv file is written with the metrics. By default the csv file will be named as the name of the video file in the same directory.
+5. For both video and webcam options, a csv file is written with the metrics. By default the csv file will be named "default.csv".
 
 6. When a webcam is used as an input, the script displays real-time metrics on the screen.
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ This script demonstrates how to use Affectiva's affvisionpy module to process fr
 
 1. Make sure you have **affvisionpy**
 
-2. **cd** into the directory containing the setup.py script and run: **sudo python3 setup.py install**.
-
-    Alternative to step 2 : **cd** into the directory having the requirements.txt file and run **pip3 install -r requirements.txt**
+2. **cd** into the directory having the requirements.txt file and run **pip3 install -r requirements.txt**
 
 
 ## Steps to run the script: ##
@@ -41,9 +39,9 @@ This script demonstrates how to use Affectiva's affvisionpy module to process fr
 
           -r --resolution WIDTH HEIGHT   set the resolution in pixels (width, height) for the webcam. Defaults to 1280 x 720 resolution.
           
-    **Note**: if only the data argument is supplied, the script defaults the run to a webcam and 1 face detection, with the output written to "default.csv"
-    displaying frames at default size of 1280 x 720. Only certain standard frame sizes are supported. For any unsupported frame sizes, the webcam frame size defaults
-    to 1280 x 720. If any other configuration is required, it can be done using optional arguments.
+    **Note**: if only the data argument is supplied, the script defaults the run to a webcam and 1 face detection, displaying frames 
+    at default size of 1280 x 720. Only certain standard frame sizes are supported. For any unsupported frame sizes, the webcam frame 
+    size defaults to 1280 x 720. If any other configuration is required, it can be done using optional arguments.
 
 
 
@@ -79,10 +77,10 @@ This script demonstrates how to use Affectiva's affvisionpy module to process fr
 
 ## Additional Notes ##
 
-5.  For both video and webcam options, a CSV file is written with the metrics. By default, the CSV file will be named "default.csv".
+5.  For the video option, a CSV file is written with the metrics. By default, the CSV file will be named with the same name as the video file.
 
 6.  For both video and webcam options, the script displays real-time metrics on the screen.
 
-7.  To get the output metrics in a file of your choice, give the name of the file with -f on the command line.
+7.  To get the output metrics in a file of your choice, give the name of the file with -f on the command line. If a CSV file is desired for the webcam option, the -f flag must be supplied. 
 
 8.  To get the output video, use the option -o along with the output file name.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sample Python App for Affdex SDK #
 
-This script is the python-sdk-sample for the frame detector demo.
+This script demonstrates how to use Affectiva's affvisionpy module to process frames from either a webcam or a video file. It supports displaying the input frames on screen, overlaid with metric values, and can also write the metric values to an output CSV file as well as a video AVI file.
 
 ## Steps to install the app: ##
 

--- a/README.md
+++ b/README.md
@@ -4,62 +4,77 @@ Steps to install the app:
 
 1. Make sure you have affvisionpy
 
-2. cd into the directory having the requirements.txt file and run **pip3 install -r requirements.txt**
+2. cd into the directory containing the setup.py script and run: sudo python3 setup.py install.
+
+   Alternative to step 2 : cd into the directory having the requirements.txt file and run "pip3 install -r requirements.txt"
 
 
 Steps to run the script:
 
-1. usage: 
-    
+1. usage:
 
-        affvisionpy-sample.py [-h] -d DATA [-i VIDEO] [-n NUM_FACES] [-c [CAMERA]] [-o OUTPUT] [-f FILE]
-        
+        python3 affvisionpy-sample.py [-h] -d DATA [-v VIDEO] [-n NUM_FACES] [-c [CAMERA]] [-o OUTPUT] [-f FILE] [-r WIDTH HEIGHT]
+
         required arguments:
-        
+
             -d DATA, --data DATA  path to directory containing the models
-            
+
 
         optional arguments:
-    
+
           -h, --help            show this help message and exit
-      
-          -i VIDEO, --input VIDEO
+
+          -v VIDEO, --video VIDEO
                         path to input video file
-                        
+
           -n NUM_FACES, --num_faces NUM_FACES
                         number of faces to identify in the frame
-                        
+
           -o OUTPUT, --output OUTPUT
-                        name of the output video file
-          
+                        enable this parameter to save the output video in a video file of your choice
+
           -f FILE, --file FILE
-                        name of the output csv file
-                        
+                        enable this parameter to save the output metrics in a csv file of your choice
+
           -c [CAMERA], --camera [CAMERA]
                         enable this parameter take input from the webcam and provide a camera id for the webcam
-                        
-        Note: if only data argument is supplied, the script defaults the run to a webcam and 1 face detection. If any other configuration is required, it can be done using optional arguments.
-        
+
+          -x --no-save  set this flag to disable outputting individual frame files.
+
+          -r --resolution WIDTH HEIGHT set the resolution in pixels (width, height) for the webcam. Defaults to 1280 x 720 resolution.
+
+        Note: if only data argument is supplied, the script defaults the run to a webcam and 1 face detection, with the output written to "output.csv" and "output.avi"
+        displaying frames at default size of 1280 x 720. Only certain standard frame sizes are supported. For any unsupported frame sizes, the webcam frame size defaults
+        to 1280 x 720. If any other configuration is required, it can be done using optional arguments.
+
+
 
 2. We can use the same script to enable camera as well as input video.
 
 3. By default the num of faces detected by the script is 1.
 
-4. 
+4.
 
-    i. Command to run the script with webcam: 
+    i. Command to run the script with webcam:
 
             python3 affvisionpy-sample.py -d <path/to/data/directory> -c <camera_id> -n <num_of_faces_to_detect>
-            
+
             Note: If the camera id is not supplied, by default the camera_id 0 is taken
-        
+
     ii. Command to run the script with a video file:
-    
-            python3 affvisionpy-sample.py -d <path/to/data/directory> -n <num_of_faces_to_detect> -i </path/to/video/file>
-        
-    
-5. When a video file is provided as an input, a csv file is written with the metrics. By default the csv file will
-    be named as the name of the video file.
+
+            python3 affvisionpy-sample.py -d <path/to/data/directory> -n <num_of_faces_to_detect> -v </path/to/video/file>
+
+            When a video file is provided as an input, a csv file is written with the metrics. By default the csv file will be named as the name of the video file.
+
+            When a webcam is used as an input, the script displays real-time metrics on the screen.
+
+            To get the output metrics in a file of your choice, give the name of the file with -f on the command line.
+
+            To get the output video, use the option -o along with the output file name.
+
+
+5. When a video file is provided as an input, a csv file is written with the metrics. By default the csv file will be named as the name of the video file in the same directory.
 
 6. When a webcam is used as an input, the script displays real-time metrics on the screen.
 

--- a/python-sdk-samples/affvisionpy-sample.py
+++ b/python-sdk-samples/affvisionpy-sample.py
@@ -230,7 +230,7 @@ def display_measurements_on_screen(key, val, upper_left_y, frame, x1):
 
     """
     key = str(key)
-
+    padding = 20
     key_name = key.split(".")[1]
     key_text_width, key_text_height = get_text_size(key_name, cv2.FONT_HERSHEY_SIMPLEX, 1)
     val_text = str(round(val, 2))
@@ -238,11 +238,11 @@ def display_measurements_on_screen(key, val, upper_left_y, frame, x1):
 
     key_val_width = key_text_width + val_text_width
 
-    cv2.putText(frame, key_name + ": ", (abs(x1 - key_val_width), upper_left_y),
+    cv2.putText(frame, key_name + ": ", (abs(x1 - key_val_width - PADDING_FOR_SEPARATOR), upper_left_y),
                 cv2.FONT_HERSHEY_SIMPLEX,
                 TEXT_SIZE,
                 (255, 255, 255))
-    cv2.putText(frame, val_text, (abs(x1 - val_text_width + PADDING_FOR_SEPARATOR), upper_left_y),
+    cv2.putText(frame, val_text, (abs(x1 - val_text_width), upper_left_y),
                 cv2.FONT_HERSHEY_SIMPLEX, TEXT_SIZE,
                 (255, 255, 255))
 
@@ -292,7 +292,7 @@ def display_emotions_on_screen(key, val, upper_left_y, frame, x1):
     rounded_val /= 10
     rounded_val = abs(int(rounded_val))
 
-    for i in range(0, rounded_val + 1):
+    for i in range(0, rounded_val):
         start_box_point_x += 10
         cv2.rectangle(overlay, (start_box_point_x, upper_left_y),
                       (start_box_point_x + width, upper_left_y - height), (186, 186, 186), -1)
@@ -347,13 +347,13 @@ def display_expressions_on_screen(key, val, upper_right_x, upper_right_y, frame,
         rounded_val = roundup(val)
         rounded_val /= 10
         rounded_val = int(rounded_val)
-        for i in range(0, rounded_val):
+        for i in range(0, rounded_val ):
             start_box_point_x += 10
             cv2.rectangle(overlay, (start_box_point_x, upper_right_y),
                           (start_box_point_x + width, upper_right_y - height), (186, 186, 186), -1)
             cv2.rectangle(overlay, (start_box_point_x, upper_right_y),
                           (start_box_point_x + width, upper_right_y - height), (0, 204, 102), -1)
-        for i in range(rounded_val + 1, 10):
+        for i in range(rounded_val, 10):
             start_box_point_x += 10
             cv2.rectangle(overlay, (start_box_point_x, upper_right_y),
                           (start_box_point_x + width, upper_right_y - height), (186, 186, 186), -1)
@@ -436,26 +436,27 @@ def run(csv_data):
 
     captureFile = cv2.VideoCapture(input_file)
     window = cv2.namedWindow('Processed Frame', cv2.WINDOW_NORMAL)
-    cv2.resizeWindow('Processed Frame', frame_width, frame_height)
 
     if not args.video:
+        cv2.resizeWindow('Processed Frame', frame_width, frame_height)
         captureFile.set(cv2.CAP_PROP_FRAME_HEIGHT, frame_height)
         captureFile.set(cv2.CAP_PROP_FRAME_WIDTH, frame_width)
         #If cv2 silently fails, default to 1280 x 720 instead of 640 x 480
         if captureFile.get(3) != frame_width or captureFile.get(4) != frame_height:
             print(f"{frame_width} x {frame_height} is an unsupported resolution, defaulting to 1280 x 720")
+            cv2.resizeWindow('Processed Frame',DEFAULT_FRAME_WIDTH, DEFAULT_FRAME_HEIGHT)
             captureFile.set(cv2.CAP_PROP_FRAME_HEIGHT, DEFAULT_FRAME_HEIGHT)
             captureFile.set(cv2.CAP_PROP_FRAME_WIDTH, DEFAULT_FRAME_WIDTH)
             frame_width = DEFAULT_FRAME_WIDTH
             frame_height = DEFAULT_FRAME_HEIGHT
-            cv2.resizeWindow('Processed Frame',DEFAULT_FRAME_WIDTH, DEFAULT_FRAME_HEIGHT)
+
         file_width = frame_width
         file_height = frame_height
 
     else:
         file_width = int(captureFile.get(3))
         file_height = int(captureFile.get(4))
-        #cv2.resizeWindow('Processed Frame', file_width,file_height)
+        cv2.resizeWindow('Processed Frame', file_width, file_height)
 
     if output_file is not None:
        out = cv2.VideoWriter(output_file, cv2.VideoWriter_fourcc('M', 'J', 'P', 'G'), 10, (file_width, file_height))
@@ -604,6 +605,7 @@ def write_metrics_to_csv_data_list(csv_data, timestamp):
         csv_data.append(current_frame_data)
     else:
         for fid in measurements_dict.keys():
+            current_frame_data = {}
             current_frame_data["TimeStamp"] = timestamp
             current_frame_data["faceId"] = fid
             upperLeftX, upperLeftY, lowerRightX, lowerRightY = get_bounding_box_points(fid)

--- a/python-sdk-samples/affvisionpy-sample.py
+++ b/python-sdk-samples/affvisionpy-sample.py
@@ -4,33 +4,41 @@ import csv
 import os
 import time
 from collections import defaultdict
+from collections import namedtuple
 
 import affvisionpy as af
 import cv2 as cv2
 import math
 
+
 # Constants
 NOT_A_NUMBER = 'NaN'
 count = 0
-TEXT_SIZE = 0.4
+TEXT_SIZE = 0.7
 PADDING_FOR_SEPARATOR = 5
 THRESHOLD_VALUE_FOR_EMOTIONS = 5
 DECIMAL_ROUNDING_FACTOR = 2
+DEFAULT_FRAME_WIDTH = 1280
+DEFAULT_FRAME_HEIGHT = 720
+DEFAULT_FILE_NAME = "output"
 
 process_last_ts = 0.0
 capture_last_ts = 0.0
+
+Mood = namedtuple("Mood",['mood','confidence','dominant_emotion','dominant_emotion_confidence'])
 
 measurements_dict = defaultdict()
 expressions_dict = defaultdict()
 emotions_dict = defaultdict()
 bounding_box_dict = defaultdict()
+mood_dict = defaultdict()
+
+"""Listener class that return metrics for processed frames.
+
+"""
 
 
 class Listener(af.ImageListener):
-    """Listener class that return metrics for processed frames.
-
-    """
-
     def __init__(self):
         super(Listener, self).__init__()
 
@@ -49,6 +57,8 @@ class Listener(af.ImageListener):
             measurements_dict[face.get_id()].update(face.get_measurements())
             expressions_dict[face.get_id()].update(face.get_expressions())
             emotions_dict[face.get_id()].update(face.get_emotions())
+            mood_dict[face.get_id()] = Mood(mood=face.get_mood(),confidence=face.get_confidence(),dominant_emotion=face.get_dominant_emotion().dominant_emotion,
+                                            dominant_emotion_confidence=face.get_dominant_emotion().confidence)
             bounding_box_dict[face.get_id()] = [face.get_bounding_box()[0].x,
                                                 face.get_bounding_box()[0].y,
                                                 face.get_bounding_box()[1].x,
@@ -61,43 +71,71 @@ class Listener(af.ImageListener):
         capture_last_ts = image.timestamp()
 
 
+"""read parameters entered on the command line.
+
+    Parameters
+    ----------
+    args: argparse
+        object of argparse module
+
+    Returns
+    -------
+    tuple of str values
+        details about input file name, data directory, num of faces to detect, output file name
+    """
+
+
 def get_command_line_parameters(args):
-    """read parameters entered on the command line.
-
-        Parameters
-        ----------
-        args: argparse
-            object of argparse module
-
-        Returns
-        -------
-        tuple of str values
-            details about input file name, data directory, num of faces to detect, output file name
-        """
     if not args.video is None:
         input_file = args.video
         if not os.path.isfile(input_file):
             raise ValueError("Please provide a valid input video file")
     else:
         input_file = int(args.camera)
+
+    if args.video and not args.file:
+        try:
+            csv_file = input_file.split('.')[0] + '.csv'
+        except Exception as exp:
+            print(exp)
+            raise ValueError("Please provide a valid input video file")
+    elif args.file:
+        csv_file = args.file
+    else:
+        csv_file = DEFAULT_FILE_NAME + '.csv'
+
+    if args.video and not args.output:
+        try:
+            output_file = input_file.split('.')[0] + '.avi'
+        except Exception as exp:
+            print(exp)
+            raise ValueError("Please provide a valid input video file")
+    elif args.output:
+        output_file = args.output
+    else:
+        output_file = DEFAULT_FILE_NAME + '.avi'
+
     data = args.data
     if not os.path.isdir(data):
         raise ValueError("Please check your data directory path")
     max_num_of_faces = int(args.num_faces)
-    output_file = args.output
-    csv_file = args.file
-    return input_file, data, max_num_of_faces, csv_file, output_file
+    no_save = args.no_save
+    frame_width = int(args.res[0])
+    frame_height= int(args.res[1])
+    return input_file, data, max_num_of_faces, output_file, csv_file, no_save, frame_width, frame_height
+
+
+"""For each frame, draw the bounding box on screen.
+
+    Parameters
+    ----------
+    frame: affvisionPy.Frame
+        Frame object to draw the bounding box on.
+
+    """
 
 
 def draw_bounding_box(frame):
-    """For each frame, draw the bounding box on screen.
-
-        Parameters
-        ----------
-        frame: affvisionPy.Frame
-            Frame object to draw the bounding box on.
-
-        """
     for fid, bb_points in bounding_box_dict.items():
         x1, y1, x2, y2 = get_bounding_box_points(fid)
         for key in emotions_dict[fid]:
@@ -115,80 +153,86 @@ def draw_bounding_box(frame):
             cv2.rectangle(frame, (x1, y1), (x2, y2), (21, 169, 167), 3)
 
 
+"""Fetch upper left_x, upper left_y, upper_right_x,upper_right_y points of the bounding box.
+
+    Parameters
+    ----------
+    fid: int
+        face id of the face to get the bounding box for
+
+    Returns
+    -------
+    tuple of int values
+        tuple with upper left_x, upper left_y, upper_right_x,upper_right_y values
+    """
+
+
 def get_bounding_box_points(fid):
-    """Fetch upper left_x, upper left_y, upper_right_x,upper_right_y points of the bounding box.
-
-        Parameters
-        ----------
-        fid: int
-            face id of the face to get the bounding box for
-
-        Returns
-        -------
-        tuple of int values
-            tuple with upper left_x, upper left_y, upper_right_x,upper_right_y values
-        """
     return (int(bounding_box_dict[fid][0]),
             int(bounding_box_dict[fid][1]),
             int(bounding_box_dict[fid][2]),
             int(bounding_box_dict[fid][3]))
 
 
+"""Round up the number to the nearest 10.
+
+   Parameters
+   ----------
+   num: int
+       number to be rounded up to 10.
+
+   Returns
+   -------
+   int
+       Rounded up value of the number to 10
+   """
+
+
 def roundup(num):
-    """Round up the number to the nearest 10.
-
-       Parameters
-       ----------
-       num: int
-           number to be rounded up to 10.
-
-       Returns
-       -------
-       int
-           Rounded value of the number to 10
-       """
-    if (num / 10.0) < 5:
-        return int(math.floor(num / 10.0)) * 10
     return int(math.ceil(num / 10.0)) * 10
 
 
+"""Get the size occupied by a particular text string
+
+   Parameters
+   ----------
+   text: str
+       The text string to find size of.
+   font: str
+       font size of the text string
+   thickness: int
+       thickness of the font
+
+   Returns
+   -------
+   tuple of int values
+       text width, text height
+   """
+
+
 def get_text_size(text, font, thickness):
-    """Get the size occupied by a particular text string
-
-       Parameters
-       ----------
-       text: str
-           The text string to find size of.
-       font: str
-           font size of the text string
-       thickness: int
-           thickness of the font
-
-       Returns
-       -------
-       tuple of int values
-           text width, text height
-       """
     text_size = cv2.getTextSize(text, font, TEXT_SIZE, thickness)
     return text_size[0][0], text_size[0][1]
 
 
+"""Display the measurement metrics on screen.
+
+   Parameters
+   ----------
+   key: str
+       Name of the measurement.
+   val: str
+       Value of the measurement.
+   upper_left_y: int
+       the upper_left_y co-ordinate of the bounding box
+   frame: affvisionpy.Frame
+       Frame object to write the measurement on
+   x1: upper_left_x co-ordinate of the bounding box whose measurements need to be written
+
+   """
+
+
 def display_measurements_on_screen(key, val, upper_left_y, frame, x1):
-    """Display the measurement metrics on screen.
-
-       Parameters
-       ----------
-       key: str
-           Name of the measurement.
-       val: str
-           Value of the measurement.
-       upper_left_y: int
-           the upper_left_y co-ordinate of the bounding box
-       frame: affvisionpy.Frame
-           Frame object to write the measurement on
-       x1: upper_left_x co-ordinate of the bounding box whose measurements need to be written
-
-       """
     key = str(key)
 
     key_name = key.split(".")[1]
@@ -207,22 +251,24 @@ def display_measurements_on_screen(key, val, upper_left_y, frame, x1):
                 (255, 255, 255))
 
 
+"""Display the emotion metrics on screen.
+
+    Parameters
+    ----------
+    key: str
+        Name of the emotion.
+    val: str
+        Value of the emotion.
+    upper_left_y: int
+        the upper_left_y co-ordinate of the bounding box
+    frame: affvisionpy.Frame
+        Frame object to write the measurement on
+    x1: upper_left_x co-ordinate of the bounding box whose measurements need to be written
+
+"""
+
+
 def display_emotions_on_screen(key, val, upper_left_y, frame, x1):
-    """Display the emotion metrics on screen.
-
-        Parameters
-        ----------
-        key: str
-            Name of the emotion.
-        val: str
-            Value of the emotion.
-        upper_left_y: int
-            the upper_left_y co-ordinate of the bounding box
-        frame: affvisionpy.Frame
-            Frame object to write the measurement on
-        x1: upper_left_x co-ordinate of the bounding box whose measurements need to be written
-
-    """
     key = str(key)
     key_name = key.split(".")[1]
     key_text_width, key_text_height = get_text_size(key_name, cv2.FONT_HERSHEY_SIMPLEX, 1)
@@ -246,7 +292,7 @@ def display_emotions_on_screen(key, val, upper_left_y, frame, x1):
     rounded_val /= 10
     rounded_val = abs(int(rounded_val))
 
-    for i in range(0, rounded_val):
+    for i in range(0, rounded_val + 1):
         start_box_point_x += 10
         cv2.rectangle(overlay, (start_box_point_x, upper_left_y),
                       (start_box_point_x + width, upper_left_y - height), (186, 186, 186), -1)
@@ -256,7 +302,7 @@ def display_emotions_on_screen(key, val, upper_left_y, frame, x1):
         else:
             cv2.rectangle(overlay, (start_box_point_x, upper_left_y),
                           (start_box_point_x + width, upper_left_y - height), (0, 204, 102), -1)
-    for i in range(rounded_val, 10):
+    for i in range(rounded_val + 1, 11):
         start_box_point_x += 10
         cv2.rectangle(overlay, (start_box_point_x, upper_left_y),
                       (start_box_point_x + width, upper_left_y - height), (186, 186, 186), -1)
@@ -265,24 +311,26 @@ def display_emotions_on_screen(key, val, upper_left_y, frame, x1):
     cv2.addWeighted(overlay, alpha, frame, 1 - alpha, 0, frame)
 
 
+"""Display the expressions metrics on screen.
+
+    Parameters
+    ----------
+    key: str
+        Name of the emotion.
+    val: str
+        Value of the emotion.
+    upper_right_x: int
+        the upper_left_x co-ordinate of the bounding box
+    upper_right_y: int
+        the upper_left_y co-ordinate of the bounding box
+    frame: affvisionpy.Frame
+        Frame object to write the measurement on
+    upper_left_y: upper_left_y co-ordinate of the bounding box whose measurements need to be written
+
+"""
+
+
 def display_expressions_on_screen(key, val, upper_right_x, upper_right_y, frame, upper_left_y):
-    """Display the emotion metrics on screen.
-
-        Parameters
-        ----------
-        key: str
-            Name of the emotion.
-        val: str
-            Value of the emotion.
-        upper_right_x: int
-            the upper_left_x co-ordinate of the bounding box
-        upper_right_y: int
-            the upper_left_y co-ordinate of the bounding box
-        frame: affvisionpy.Frame
-            Frame object to write the measurement on
-        upper_left_y: upper_left_y co-ordinate of the bounding box whose measurements need to be written
-
-    """
     key = str(key)
 
     key_name = key.split(".")[1]
@@ -299,13 +347,13 @@ def display_expressions_on_screen(key, val, upper_right_x, upper_right_y, frame,
         rounded_val = roundup(val)
         rounded_val /= 10
         rounded_val = int(rounded_val)
-        for i in range(0, rounded_val):
+        for i in range(0, rounded_val + 1):
             start_box_point_x += 10
             cv2.rectangle(overlay, (start_box_point_x, upper_right_y),
                           (start_box_point_x + width, upper_right_y - height), (186, 186, 186), -1)
             cv2.rectangle(overlay, (start_box_point_x, upper_right_y),
                           (start_box_point_x + width, upper_right_y - height), (0, 204, 102), -1)
-        for i in range(rounded_val + 1, 10):
+        for i in range(rounded_val + 1, 11):
             start_box_point_x += 10
             cv2.rectangle(overlay, (start_box_point_x, upper_right_y),
                           (start_box_point_x + width, upper_right_y - height), (186, 186, 186), -1)
@@ -322,15 +370,17 @@ def display_expressions_on_screen(key, val, upper_right_x, upper_right_y, frame,
                 (255, 255, 255))
 
 
+"""write measurements, emotions,expressions on screen
+
+   Parameters
+   ----------
+   frame: affvisionpy.Frame
+        frame to write the metrics on
+
+   """
+
+
 def write_metrics(frame):
-    """write measurements, emotions,expressions on screen
-
-       Parameters
-       ----------
-       frame: affvisionpy.Frame
-            frame to write the metrics on
-
-       """
     for fid in measurements_dict.keys():
         measurements = measurements_dict[fid]
         expressions = expressions_dict[fid]
@@ -357,16 +407,18 @@ def write_metrics(frame):
             upper_right_y += 25
 
 
-def run(csv_data):
-    """Starting point of the program, initializes the detctor, processes a frame and then writes metrics to frame
+"""Starting point of the program, initializes the detctor, processes a frame and then writes metrics to frame
 
-       Parameters
-       ----------
-       csv_data: list
-            Values to hold for each frame
-       """
+   Parameters
+   ----------
+   csv_data: list
+        Values to hold for each frame
+   """
+
+
+def run(csv_data):
     args = parse_command_line()
-    input_file, data, max_num_of_faces, csv_file, output_file = get_command_line_parameters(args)
+    input_file, data, max_num_of_faces, output_file, csv_file, no_save, frame_width, frame_height = get_command_line_parameters(args)
     if isinstance(input_file, int):
         start_time = time.time()
     detector = af.SyncFrameDetector(data, max_num_of_faces)
@@ -378,21 +430,38 @@ def run(csv_data):
 
     detector.start()
 
+    if not no_save:
+        if not os.path.isdir("opvideo"):
+            os.mkdir("opvideo")
+
     captureFile = cv2.VideoCapture(input_file)
+    window = cv2.namedWindow('Processed Frame',cv2.WINDOW_NORMAL)
+    cv2.resizeWindow('Processed Frame',frame_width, frame_height)
 
-    file_width = int(captureFile.get(3))
-    file_height = int(captureFile.get(4))
+    if not args.video:
+        captureFile.set(cv2.CAP_PROP_FRAME_HEIGHT, frame_height)
+        captureFile.set(cv2.CAP_PROP_FRAME_WIDTH, frame_width)
+        #If cv2 silently fails, default to 1280 x 720 instead of 640 x 480
+        if captureFile.get(3) != frame_width or captureFile.get(4) != frame_height:
+            print("Unsupported resolution, defaulting to 1280 x 720")
+            frame_width = DEFAULT_FRAME_WIDTH
+            frame_height = DEFAULT_FRAME_HEIGHT
+        file_width = frame_width
+        file_height = frame_height
 
-    if output_file is not None:
-        out = cv2.VideoWriter(output_file, cv2.VideoWriter_fourcc('M', 'J', 'P', 'G'), 10, (file_width, file_height))
+    else:
+        file_width = int(captureFile.get(3))
+        file_height = int(captureFile.get(4))
+    out = cv2.VideoWriter(output_file, cv2.VideoWriter_fourcc('M', 'J', 'P', 'G'), 10, (file_width, file_height))
     count = 0
+
+
 
     while captureFile.isOpened():
         # Capture frame-by-frame
         ret, frame = captureFile.read()
 
         if ret == True:
-
             height = frame.shape[0]
             width = frame.shape[1]
             if isinstance(input_file, int):
@@ -414,12 +483,15 @@ def run(csv_data):
                 draw_bounding_box(frame)
                 draw_affectiva_logo(frame, width, height)
                 write_metrics(frame)
+                out.write(frame)
                 cv2.imshow('Processed Frame', frame)
+                if not no_save:
+                    cv2.imwrite(os.path.join("opvideo", "frame{:d}.jpg".format(count)), frame)  # save frame as JPEG file
             else:
                 draw_affectiva_logo(frame, width, height)
                 cv2.imshow('Processed Frame', frame)
-            if output_file is not None:
-                out.write(frame)
+                if not no_save:
+                    cv2.imwrite(os.path.join("opvideo", "frame{:d}.jpg".format(count)), frame)  # save frame as JPEG file
 
             clear_all_dictionaries()
 
@@ -431,42 +503,36 @@ def run(csv_data):
     captureFile.release()
     cv2.destroyAllWindows()
     detector.stop()
+    write_csv_data_to_file(csv_data, csv_file)
 
-    # If video file is provided asa an input
-    if not isinstance(input_file, int):
-        if csv_file == "default":
-            if os.sep in csv_file:
-                csv_file = str(input_file.rsplit(os.sep, 1)[1])
-            csv_file = csv_file.split(".")[0]
-        write_csv_data_to_file(csv_data, csv_file)
-    else:
-        if not csv_file == "default":
-            write_csv_data_to_file(csv_data, csv_file)
+
+"""Clears the dictionary values
+   """
 
 
 def clear_all_dictionaries():
-    """Clears the dictionary values
-       """
     bounding_box_dict.clear()
     emotions_dict.clear()
     expressions_dict.clear()
     measurements_dict.clear()
 
 
+"""Place logo on the screen
+
+   Parameters
+   ----------
+   frame: affvisionpy.Frame
+       Frame to place the logo on
+   width: int
+       width of the frame
+   height: int
+       height of the frame
+
+   """
+
+
 def draw_affectiva_logo(frame, width, height):
-    """Place logo on the screen
-
-       Parameters
-       ----------
-       frame: affvisionpy.Frame
-           Frame to place the logo on
-       width: int
-           width of the frame
-       height: int
-           height of the frame
-
-       """
-    logo = cv2.imread(os.path.dirname(os.path.abspath(__file__)) + "/Final logo - RGB Magenta.png")
+    logo = cv2.imread("Final logo - RGB Magenta.png")
     logo_width = int(width / 3)
     logo_height = int(height / 10)
     logo = cv2.resize(logo, (logo_width, logo_height))
@@ -481,20 +547,22 @@ def draw_affectiva_logo(frame, width, height):
         frame[y1:y2, x1:x2, c] = color + beta
 
 
+"""Check if bounding box values are going outside the screen in case of face going outside
+
+   Parameters
+   ----------
+   width: int
+       width of the frame
+   height: int
+       height of the frame
+
+    Returns
+    -------
+    boolean: indicating if the bounding box is outside the frame or not
+   """
+
+
 def check_bounding_box_outside(width, height):
-    """Check if bounding box values are going outside the screen in case of face going outside
-
-       Parameters
-       ----------
-       width: int
-           width of the frame
-       height: int
-           height of the frame
-
-        Returns
-        -------
-        boolean: indicating if the bounding box is outside the frame or not
-       """
     for fid in bounding_box_dict.keys():
         x1, y1, x2, y2 = get_bounding_box_points(fid)
         if x1 < 0 or x2 > width or y1 < 0 or y2 > height:
@@ -502,83 +570,94 @@ def check_bounding_box_outside(width, height):
         return False
 
 
+"""Write metrics per frame to a list
+
+   Parameters
+   ----------
+   csv_data:
+      list of per frame values to write to
+   timestamp: int
+       timestamp of each frame
+
+   """
+
+
 def write_metrics_to_csv_data_list(csv_data, timestamp):
-    """Write metrics per frame to a list
-
-       Parameters
-       ----------
-       csv_data:
-          list of per frame values to write to
-       timestamp: int
-           timestamp of each frame
-
-       """
     for fid in measurements_dict.keys():
-        current_frame_data = list()
-        current_frame_data.append(round(timestamp, 0))
-        current_frame_data.append(fid)
-        for val in bounding_box_dict[fid]:
-            current_frame_data.append(round(val, 0))
-        for val in measurements_dict[fid].values():
-            current_frame_data.append(round(val, 4))
-        for val in emotions_dict[fid].values():
-            current_frame_data.append(round(val, 4))
-        for val in expressions_dict[fid].values():
-            current_frame_data.append(round(val, 4))
+        current_frame_data = {}
+        current_frame_data["TimeStamp"] = timestamp
+        current_frame_data["faceId"] = fid
+        x0,y0,x1,y1 = get_bounding_box_points(fid)
+        current_frame_data["upperLeftX"],current_frame_data["upperLeftY"], current_frame_data["lowerRightX"],current_frame_data["lowerRightY"] = x0,y0,x1,y1
+        for key,val in measurements_dict[fid].items():
+            current_frame_data[str(key).split('.')[1]] = round(val,4)
+        for key,val in emotions_dict[fid].items():
+            current_frame_data[str(key).split('.')[1]] = round(val,4)
+        for key,val in expressions_dict[fid].items():
+            current_frame_data[str(key).split('.')[1]] = round(val,4)
+        current_frame_data["mood"] = str(mood_dict[fid].mood).split('.')[1]
+        current_frame_data["dominant_emotion_confidence"] = round(mood_dict[fid].dominant_emotion_confidence,4)
+        current_frame_data["dominant_emotion"] = str(mood_dict[fid].dominant_emotion).split('.')[1]
+        current_frame_data["confidence"] = round(mood_dict[fid].confidence,4)
         csv_data.append(current_frame_data)
 
 
-def parse_command_line():
-    """Make the options for command line
+"""Make the options for command line
 
-       Returns
-       -------
-       args: argparse object of the command line
-       """
-    parser = argparse.ArgumentParser()
+   Returns
+   -------
+   args: argparse object of the command line
+   """
+
+
+def parse_command_line():
+    parser = argparse.ArgumentParser(description="Sample code for demoing affdexface on webcam or a saved video file.\n \
+    By default, the program will run with the camera parameter displaying frames of size 1280 x 720.\n \
+    Individual frames will be saved in opvideo directory. If video file supplied, output files will be saved with the same name by default. ")
     parser.add_argument("-d", "--data", dest="data", required=True, help="path to directory containing the models")
-    parser.add_argument("-i", "--input", dest="video", required=False,
+    parser.add_argument("-v", "--video", dest="video", required=False,
                         help="path to input video file")
     parser.add_argument("-n", "--num_faces", dest="num_faces", required=False, default=1,
                         help="number of faces to identify in the frame")
     parser.add_argument("-c", "--camera", dest="camera", required=False, const="0", nargs='?', default=0,
                         help="enable this parameter take input from the webcam and provide a camera id for the webcam")
     parser.add_argument("-o", "--output", dest="output", required=False,
-                        help="name of the output video file")
-    parser.add_argument("-f", "--file", dest="file", required=False, default="default",
-                        help="name of the output csv file")
+                        help="enable this parameter to save the output video in a video file pf your choice")
+    parser.add_argument("-f", "--file", dest="file", required=False,
+                        help="enable this parameter to save the output metrics in a csv file pf your choice")
+    parser.add_argument("-x","--no-save", dest="no_save",required=False, action="store_true",default=False, help="set this flag to disable writing output frame files")
+    parser.add_argument("-r", "--resolution",dest='res',metavar=('width','height'),nargs=2,default=[1280,720], help="resolution in pixels (2-values): width height")
     args = parser.parse_args()
     return args
 
 
+"""Place logo on the screen
+
+   Parameters
+   ----------
+   csv_data: list
+       list to write the data from
+    csv_file: list
+       file to be written to
+
+   """
+
+
 def write_csv_data_to_file(csv_data, csv_file):
-    """Place logo on the screen
-
-       Parameters
-       ----------
-       csv_data: list
-           list to write the data from
-        csv_file: list
-           file to be written to
-
-       """
-    header_row = ['TimeStamp', 'faceId', 'upperLeftX', 'upperLeftY', 'lowerRightX', 'lowerRightY', 'Pitch', 'Yaw',
-                  'Roll', 'interocularDistance', 'joy', 'anger', 'surprise',
-                  'valence',
-                  'fear', 'disgust', 'sadness', 'neutral', 'smile', 'browRaise', 'browFurrow', 'noseWrinkle',
-                  'upperLipRaise',
-                  'mouthOpen', 'eyeClosure', 'cheekRaise', 'eyeWiden', 'innerBrowRaise', 'lipCornerDepressor',
-                  'yawn', 'blink', 'blinkRate']
-    if ".csv" not in csv_file:
-        csv_file = csv_file + ".csv"
-
+    header_row = ['TimeStamp', 'faceId', 'upperLeftX','upperLeftY', 'lowerRightX', 'lowerRightY','confidence', 'interocular_distance',
+            'pitch', 'yaw','roll','joy', 'anger', 'surprise','valence','fear', 'sadness', 'disgust', 'neutral', 'smile',
+            'brow_raise', 'brow_furrow', 'nose_wrinkle', 'upper_lip_raise', 'mouth_open', 'eye_closure', 'cheek_raise', 'yawn',
+            'blink', 'blink_rate', 'eye_widen', 'inner_brow_raise', 'lip_corner_depressor', 'mood', 'dominant_emotion', 'dominant_emotion_confidence'
+            ]
+    print(csv_file,csv_data)
     with open(csv_file, 'w') as c_file:
-        writer = csv.writer(c_file, quoting=csv.QUOTE_ALL)
-        writer.writerows([header_row])
+        keys = csv_data[0].keys()
+        writer = csv.DictWriter(c_file,fieldnames=header_row)
+        writer.writeheader()
         for row in csv_data:
-            writer.writerows([row])
-        c_file.close()
+            writer.writerow(row)
 
+    c_file.close()
 
 if __name__ == "__main__":
     csv_data = list()

--- a/python-sdk-samples/affvisionpy-sample.py
+++ b/python-sdk-samples/affvisionpy-sample.py
@@ -511,14 +511,15 @@ def run(csv_data):
     detector.stop()
 
     # If video file is provided as an input
-
-    if csv_file == "default":
-        if os.sep in csv_file:
-            csv_file = str(input_file.rsplit(os.sep, 1)[1])
-        csv_file = csv_file.split(".")[0]
+    if not isinstance(input_file, int):
+        if csv_file == DEFAULT_FILE_NAME:
+            if os.sep in input_file:
+                csv_file = str(input_file.rsplit(os.sep, 1)[1])
+            csv_file = csv_file.split(".")[0]
         write_csv_data_to_file(csv_data, csv_file)
     else:
-        write_csv_data_to_file(csv_data, csv_file)
+        if not csv_file == DEFAULT_FILE_NAME:
+            write_csv_data_to_file(csv_data, csv_file)
 
 
 

--- a/python-sdk-samples/affvisionpy-sample.py
+++ b/python-sdk-samples/affvisionpy-sample.py
@@ -4,12 +4,11 @@ import csv
 import os
 import time
 from collections import defaultdict
-from collections import namedtuple
 
 import affvisionpy as af
 import cv2 as cv2
 import math
-import queue
+
 
 
 # Constants
@@ -30,20 +29,18 @@ HEIGHT = 1
 process_last_ts = 0.0
 capture_last_ts = 0.0
 
-DominantEmotion = namedtuple("DominantEmotion", ['dominant_emotion','dominant_emotion_confidence'])
+
 
 header_row = ['TimeStamp', 'faceId', 'upperLeftX', 'upperLeftY', 'lowerRightX', 'lowerRightY', 'confidence', 'interocular_distance',
         'pitch', 'yaw', 'roll', 'joy', 'anger', 'surprise', 'valence', 'fear', 'sadness', 'disgust', 'neutral', 'smile',
         'brow_raise', 'brow_furrow', 'nose_wrinkle', 'upper_lip_raise', 'mouth_open', 'eye_closure', 'cheek_raise', 'yawn',
-        'blink', 'blink_rate', 'eye_widen', 'inner_brow_raise', 'lip_corner_depressor', 'mood', 'dominant_emotion', 'dominant_emotion_confidence'
+        'blink', 'blink_rate', 'eye_widen', 'inner_brow_raise', 'lip_corner_depressor'
         ]
 
 measurements_dict = defaultdict()
 expressions_dict = defaultdict()
 emotions_dict = defaultdict()
 bounding_box_dict = defaultdict()
-mood_dict = defaultdict()
-dominant_emotion_dict = defaultdict()
 time_metrics_dict = defaultdict()
 
 
@@ -75,9 +72,6 @@ class Listener(af.ImageListener):
             measurements_dict[face.get_id()].update(face.get_measurements())
             expressions_dict[face.get_id()].update(face.get_expressions())
             emotions_dict[face.get_id()].update(face.get_emotions())
-            dominant_emotion_dict[face.get_id()] = DominantEmotion(dominant_emotion=face.get_dominant_emotion().dominant_emotion,
-                                            dominant_emotion_confidence=face.get_dominant_emotion().confidence)
-            mood_dict[face.get_id()] = face.get_mood()
             bounding_box_dict[face.get_id()] = [face.get_bounding_box()[0].x,
                                                 face.get_bounding_box()[0].y,
                                                 face.get_bounding_box()[1].x,
@@ -531,8 +525,6 @@ def clear_all_dictionaries():
     emotions_dict.clear()
     expressions_dict.clear()
     measurements_dict.clear()
-    mood_dict.clear()
-    dominant_emotion_dict.clear()
 
 
 
@@ -623,9 +615,6 @@ def write_metrics_to_csv_data_list(csv_data, timestamp):
                 current_frame_data[str(key).split('.')[1]] = round(val,4)
             for key,val in expressions_dict[fid].items():
                 current_frame_data[str(key).split('.')[1]] = round(val,4)
-            current_frame_data["mood"] = str(mood_dict[fid]).split('.')[1]
-            current_frame_data["dominant_emotion_confidence"] = round(dominant_emotion_dict[fid].dominant_emotion_confidence,4)
-            current_frame_data["dominant_emotion"] = str(dominant_emotion_dict[fid].dominant_emotion).split('.')[1]
             current_frame_data["confidence"] = round(bounding_box_dict[fid][4],4)
             csv_data.append(current_frame_data)
 

--- a/python-sdk-samples/affvisionpy-sample.py
+++ b/python-sdk-samples/affvisionpy-sample.py
@@ -11,6 +11,7 @@ import cv2 as cv2
 import math
 import queue
 
+
 # Constants
 NOT_A_NUMBER = 'NaN'
 count = 0
@@ -20,14 +21,18 @@ THRESHOLD_VALUE_FOR_EMOTIONS = 5
 DECIMAL_ROUNDING_FACTOR = 2
 DEFAULT_FRAME_WIDTH = 1280
 DEFAULT_FRAME_HEIGHT = 720
-DEFAULT_FILE_NAME = "output"
+DEFAULT_FILE_NAME = "default"
+
+#Argparse Variable Constants
+WIDTH = 0
+HEIGHT = 1
 
 process_last_ts = 0.0
 capture_last_ts = 0.0
 
-Mood = namedtuple("Mood",['mood','confidence','dominant_emotion','dominant_emotion_confidence'])
-header_row = ['TimeStamp', 'faceId', 'upperLeftX','upperLeftY', 'lowerRightX', 'lowerRightY','confidence', 'interocular_distance',
-        'pitch', 'yaw','roll','joy', 'anger', 'surprise','valence','fear', 'sadness', 'disgust', 'neutral', 'smile',
+Mood = namedtuple("Mood", ['mood','confidence','dominant_emotion','dominant_emotion_confidence'])
+header_row = ['TimeStamp', 'faceId', 'upperLeftX', 'upperLeftY', 'lowerRightX', 'lowerRightY', 'confidence', 'interocular_distance',
+        'pitch', 'yaw', 'roll', 'joy', 'anger', 'surprise', 'valence', 'fear', 'sadness', 'disgust', 'neutral', 'smile',
         'brow_raise', 'brow_furrow', 'nose_wrinkle', 'upper_lip_raise', 'mouth_open', 'eye_closure', 'cheek_raise', 'yawn',
         'blink', 'blink_rate', 'eye_widen', 'inner_brow_raise', 'lip_corner_depressor', 'mood', 'dominant_emotion', 'dominant_emotion_confidence'
         ]
@@ -37,27 +42,25 @@ expressions_dict = defaultdict()
 emotions_dict = defaultdict()
 bounding_box_dict = defaultdict()
 mood_dict = defaultdict()
-time_metrics_dict = {}
-time_metrics_dict['timestamp'] = queue.Queue(maxsize=0)
-time_metrics_dict['cfps'] = queue.Queue(maxsize=0)
-time_metrics_dict['pfps'] = queue.Queue(maxsize=0)
+time_metrics_dict = defaultdict()
 
-"""Listener class that return metrics for processed frames.
-
-"""
 
 
 class Listener(af.ImageListener):
+    """
+    Listener class that return metrics for processed frames.
+
+    """
     def __init__(self):
         super(Listener, self).__init__()
 
     def results_updated(self, faces, image):
         global process_last_ts
-        timestamp = time_metrics_dict['timestamp'].get()
-        capture_fps = time_metrics_dict['cfps'].get()
+        timestamp = time_metrics_dict['timestamp']
+        capture_fps = time_metrics_dict['cfps']
         global count
         process_fps = 1000.0 / (image.timestamp() - process_last_ts)
-        print("timestamp:" + str(round(timestamp, 0)),"Frame " + str(count),"cfps: " + str(round(capture_fps, 0)), "pfps: " + str(round(process_fps, 0)))
+        print("timestamp:" + str(round(timestamp, 0)), "Frame " + str(count), "cfps: " + str(round(capture_fps, 0)), "pfps: " + str(round(process_fps, 0)))
         count +=1
         process_last_ts = image.timestamp()
         self.faces = faces
@@ -70,7 +73,7 @@ class Listener(af.ImageListener):
             measurements_dict[face.get_id()].update(face.get_measurements())
             expressions_dict[face.get_id()].update(face.get_expressions())
             emotions_dict[face.get_id()].update(face.get_emotions())
-            mood_dict[face.get_id()] = Mood(mood=face.get_mood(),confidence=face.get_confidence(),dominant_emotion=face.get_dominant_emotion().dominant_emotion,
+            mood_dict[face.get_id()] = Mood(mood=face.get_mood(), confidence=face.get_confidence(), dominant_emotion=face.get_dominant_emotion().dominant_emotion,
                                             dominant_emotion_confidence=face.get_dominant_emotion().confidence)
             bounding_box_dict[face.get_id()] = [face.get_bounding_box()[0].x,
                                                 face.get_bounding_box()[0].y,
@@ -80,25 +83,25 @@ class Listener(af.ImageListener):
     def image_captured(self, image):
         global capture_last_ts
         capture_fps = 1000.0 / (image.timestamp() - capture_last_ts)
-        time_metrics_dict['cfps'].put(capture_fps)
+        time_metrics_dict['cfps'] = capture_fps
         capture_last_ts = image.timestamp()
 
 
-"""read parameters entered on the command line.
-
-    Parameters
-    ----------
-    args: argparse
-        object of argparse module
-
-    Returns
-    -------
-    tuple of str values
-        details about input file name, data directory, num of faces to detect, output file name
-    """
-
 
 def get_command_line_parameters(args):
+    """
+    read parameters entered on the command line.
+
+        Parameters
+        ----------
+        args: argparse
+            object of argparse module
+
+        Returns
+        -------
+        tuple of str values
+            details about input file name, data directory, num of faces to detect, output file name
+    """
     if not args.video is None:
         input_file = args.video
         if not os.path.isfile(input_file):
@@ -111,24 +114,24 @@ def get_command_line_parameters(args):
     max_num_of_faces = int(args.num_faces)
     output_file = args.output
     csv_file = args.file
-    frame_width = int(args.res[0])
-    frame_height= int(args.res[1])
+    frame_width = int(args.res[WIDTH])
+    frame_height= int(args.res[HEIGHT])
     return input_file, data, max_num_of_faces, csv_file, output_file, frame_width, frame_height
 
 
-"""For each frame, draw the bounding box on screen.
-
-    Parameters
-    ----------
-    frame: affvisionPy.Frame
-        Frame object to draw the bounding box on.
-
-    """
-
 
 def draw_bounding_box(frame):
+    """
+    For each frame, draw the bounding box on screen.
+
+        Parameters
+        ----------
+        frame: affvisionPy.Frame
+            Frame object to draw the bounding box on.
+
+    """
     for fid, bb_points in bounding_box_dict.items():
-        x1, y1, x2, y2 = get_bounding_box_points(fid)
+        upper_left_x, upper_left_y, lower_right_x, lower_right_y = get_bounding_box_points(fid)
         for key in emotions_dict[fid]:
             if 'valence' in str(key):
                 valence_value = emotions_dict[fid][key]
@@ -137,95 +140,95 @@ def draw_bounding_box(frame):
             if 'joy' in str(key):
                 joy_value = emotions_dict[fid][key]
         if valence_value < 0 and anger_value >= THRESHOLD_VALUE_FOR_EMOTIONS:
-            cv2.rectangle(frame, (x1, y1), (x2, y2), (0, 0, 255), 3)
+            cv2.rectangle(frame, (upper_left_x, upper_left_y), (lower_right_x, lower_right_y), (0, 0, 255), 3)
         elif valence_value >= THRESHOLD_VALUE_FOR_EMOTIONS and joy_value >= THRESHOLD_VALUE_FOR_EMOTIONS:
-            cv2.rectangle(frame, (x1, y1), (x2, y2), (0, 255, 0), 3)
+            cv2.rectangle(frame, (upper_left_x, upper_left_y), (lower_right_x, lower_right_y), (0, 255, 0), 3)
         else:
-            cv2.rectangle(frame, (x1, y1), (x2, y2), (21, 169, 167), 3)
+            cv2.rectangle(frame, (upper_left_x, upper_left_y), (lower_right_x, lower_right_y), (21, 169, 167), 3)
 
-
-"""Fetch upper left_x, upper left_y, upper_right_x,upper_right_y points of the bounding box.
-
-    Parameters
-    ----------
-    fid: int
-        face id of the face to get the bounding box for
-
-    Returns
-    -------
-    tuple of int values
-        tuple with upper left_x, upper left_y, upper_right_x,upper_right_y values
-    """
 
 
 def get_bounding_box_points(fid):
+    """
+    Fetch upper_left_x, upper_left_y, upper_right_x, upper_right_y points of the bounding box.
+
+        Parameters
+        ----------
+        fid: int
+            face id of the face to get the bounding box for
+
+        Returns
+        -------
+        tuple of int values
+            tuple with upper_left_x, upper_left_y, upper_right_x, upper_right_y values
+    """
     return (int(bounding_box_dict[fid][0]),
             int(bounding_box_dict[fid][1]),
             int(bounding_box_dict[fid][2]),
             int(bounding_box_dict[fid][3]))
 
 
-"""Round up the number to the nearest 10.
-
-   Parameters
-   ----------
-   num: int
-       number to be rounded up to 10.
-
-   Returns
-   -------
-   int
-       Rounded up value of the number to 10
-   """
-
 
 def roundup(num):
+    """
+    Round up the number to the nearest 10.
+
+       Parameters
+       ----------
+       num: int
+           number to be rounded up to 10.
+
+       Returns
+       -------
+       int
+           Rounded up value of the number to 10
+    """
     if (num / 10.0) < 5:
         return int(math.floor(num / 10.0)) * 10
     return int(math.ceil(num / 10.0)) * 10
 
 
-"""Get the size occupied by a particular text string
-
-   Parameters
-   ----------
-   text: str
-       The text string to find size of.
-   font: str
-       font size of the text string
-   thickness: int
-       thickness of the font
-
-   Returns
-   -------
-   tuple of int values
-       text width, text height
-   """
-
 
 def get_text_size(text, font, thickness):
+    """
+    Get the size occupied by a particular text string
+
+       Parameters
+       ----------
+       text: str
+           The text string to find size of.
+       font: str
+           font size of the text string
+       thickness: int
+           thickness of the font
+
+       Returns
+       -------
+       tuple of int values
+           text width, text height
+    """
     text_size = cv2.getTextSize(text, font, TEXT_SIZE, thickness)
     return text_size[0][0], text_size[0][1]
 
 
-"""Display the measurement metrics on screen.
-
-   Parameters
-   ----------
-   key: str
-       Name of the measurement.
-   val: str
-       Value of the measurement.
-   upper_left_y: int
-       the upper_left_y co-ordinate of the bounding box
-   frame: affvisionpy.Frame
-       Frame object to write the measurement on
-   x1: upper_left_x co-ordinate of the bounding box whose measurements need to be written
-
-   """
-
 
 def display_measurements_on_screen(key, val, upper_left_y, frame, x1):
+    """
+    Display the measurement metrics on screen.
+
+       Parameters
+       ----------
+       key: str
+           Name of the measurement.
+       val: str
+           Value of the measurement.
+       upper_left_y: int
+           the upper_left_y co-ordinate of the bounding box
+       frame: affvisionpy.Frame
+           Frame object to write the measurement on
+       x1: upper_left_x co-ordinate of the bounding box whose measurements need to be written
+
+    """
     key = str(key)
 
     key_name = key.split(".")[1]
@@ -244,24 +247,24 @@ def display_measurements_on_screen(key, val, upper_left_y, frame, x1):
                 (255, 255, 255))
 
 
-"""Display the emotion metrics on screen.
-
-    Parameters
-    ----------
-    key: str
-        Name of the emotion.
-    val: str
-        Value of the emotion.
-    upper_left_y: int
-        the upper_left_y co-ordinate of the bounding box
-    frame: affvisionpy.Frame
-        Frame object to write the measurement on
-    x1: upper_left_x co-ordinate of the bounding box whose measurements need to be written
-
-"""
-
 
 def display_emotions_on_screen(key, val, upper_left_y, frame, x1):
+    """
+    Display the emotion metrics on screen.
+
+        Parameters
+        ----------
+        key: str
+            Name of the emotion.
+        val: str
+            Value of the emotion.
+        upper_left_y: int
+            the upper_left_y co-ordinate of the bounding box
+        frame: affvisionpy.Frame
+            Frame object to write the measurement on
+        x1: upper_left_x co-ordinate of the bounding box whose measurements need to be written
+
+    """
     key = str(key)
     key_name = key.split(".")[1]
     key_text_width, key_text_height = get_text_size(key_name, cv2.FONT_HERSHEY_SIMPLEX, 1)
@@ -271,11 +274,11 @@ def display_emotions_on_screen(key, val, upper_left_y, frame, x1):
     cv2.putText(frame, key_name + ": ", (abs(x1 - key_val_width), upper_left_y),
                 cv2.FONT_HERSHEY_SIMPLEX,
                 TEXT_SIZE,
-                (0, 0,0),4,cv2.LINE_AA)
+                (0, 0,0), 4, cv2.LINE_AA)
     cv2.putText(frame, key_name + ": ", (abs(x1 - key_val_width), upper_left_y),
                 cv2.FONT_HERSHEY_SIMPLEX,
                 TEXT_SIZE,
-                (255, 255, 255),2,cv2.LINE_AA)
+                (255, 255, 255), 2, cv2.LINE_AA)
     overlay = frame.copy()
 
     if math.isnan(val):
@@ -308,26 +311,26 @@ def display_emotions_on_screen(key, val, upper_left_y, frame, x1):
     cv2.addWeighted(overlay, alpha, frame, 1 - alpha, 0, frame)
 
 
-"""Display the expressions metrics on screen.
-
-    Parameters
-    ----------
-    key: str
-        Name of the emotion.
-    val: str
-        Value of the emotion.
-    upper_right_x: int
-        the upper_left_x co-ordinate of the bounding box
-    upper_right_y: int
-        the upper_left_y co-ordinate of the bounding box
-    frame: affvisionpy.Frame
-        Frame object to write the measurement on
-    upper_left_y: upper_left_y co-ordinate of the bounding box whose measurements need to be written
-
-"""
-
 
 def display_expressions_on_screen(key, val, upper_right_x, upper_right_y, frame, upper_left_y):
+    """
+    Display the expressions metrics on screen.
+
+        Parameters
+        ----------
+        key: str
+            Name of the emotion.
+        val: str
+            Value of the emotion.
+        upper_right_x: int
+            the upper_left_x co-ordinate of the bounding box
+        upper_right_y: int
+            the upper_left_y co-ordinate of the bounding box
+        frame: affvisionpy.Frame
+            Frame object to write the measurement on
+        upper_left_y: upper_left_y co-ordinate of the bounding box whose measurements need to be written
+
+    """
     key = str(key)
 
     key_name = key.split(".")[1]
@@ -360,45 +363,46 @@ def display_expressions_on_screen(key, val, upper_right_x, upper_right_y, frame,
         upper_left_y += 25
     else:
         cv2.putText(frame, str(val), (upper_right_x, upper_right_y), cv2.FONT_HERSHEY_DUPLEX, TEXT_SIZE,
-                    (0, 0, 0),2,cv2.LINE_AA)
+                    (0, 0, 0), 2, cv2.LINE_AA)
         cv2.putText(frame, str(val), (upper_right_x, upper_right_y), cv2.FONT_HERSHEY_DUPLEX, TEXT_SIZE,
-                    (255, 255, 255),1,cv2.LINE_AA)
+                    (255, 255, 255), 1, cv2.LINE_AA)
+
     cv2.putText(frame, " :" + str(key_name), (upper_right_x + val_rect_width, upper_right_y), cv2.FONT_HERSHEY_DUPLEX,
                 TEXT_SIZE,
-                (0, 0, 0),4,cv2.LINE_AA)
+                (0, 0, 0), 4, cv2.LINE_AA)
     cv2.putText(frame, " :" + str(key_name), (upper_right_x + val_rect_width, upper_right_y), cv2.FONT_HERSHEY_DUPLEX,
                 TEXT_SIZE,
-                (255, 255, 255),1,cv2.LINE_AA)
+                (255, 255, 255), 1, cv2.LINE_AA)
 
-"""write measurements, emotions,expressions on screen
-
-   Parameters
-   ----------
-   frame: affvisionpy.Frame
-        frame to write the metrics on
-
-   """
 
 
 def write_metrics(frame):
+    """
+    write measurements, emotions, expressions on screen
+
+        Parameters
+        ----------
+        frame: affvisionpy.Frame
+            frame to write the metrics on
+
+    """
     for fid in measurements_dict.keys():
         measurements = measurements_dict[fid]
         expressions = expressions_dict[fid]
         emotions = emotions_dict[fid]
-        x1, y1, x2, y2 = get_bounding_box_points(fid)
-        box_height = y2 - y1
-        box_width = x2 - x1
-        upper_left_y = y1
-        upper_right_x = x1 + box_width
-        upper_right_y = abs(y2 - box_height)
+        upper_left_x, upper_left_y, lower_right_x, lower_right_y = get_bounding_box_points(fid)
+        box_height = lower_right_y - upper_left_y
+        box_width = lower_right_x - upper_left_x
+        upper_right_x = upper_left_x + box_width
+        upper_right_y = upper_left_y
 
         for key, val in measurements.items():
-            display_measurements_on_screen(key, val, upper_left_y, frame, x1)
+            display_measurements_on_screen(key, val, upper_left_y, frame, upper_left_x)
 
             upper_left_y += 25
 
         for key, val in emotions.items():
-            display_emotions_on_screen(key, val, upper_left_y, frame, x1)
+            display_emotions_on_screen(key, val, upper_left_y, frame, upper_left_x)
             upper_left_y += 25
 
         for key, val in expressions.items():
@@ -407,16 +411,16 @@ def write_metrics(frame):
             upper_right_y += 25
 
 
-"""Starting point of the program, initializes the detctor, processes a frame and then writes metrics to frame
-
-   Parameters
-   ----------
-   csv_data: list
-        Values to hold for each frame
-   """
-
 
 def run(csv_data):
+    """
+    Starting point of the program, initializes the detector, processes a frame and then writes metrics to frame
+
+        Parameters
+        ----------
+        csv_data: list
+            Values to hold for each frame
+    """
     args = parse_command_line()
     input_file, data, max_num_of_faces, csv_file, output_file, frame_width, frame_height = get_command_line_parameters(args)
     if isinstance(input_file, int):
@@ -431,24 +435,27 @@ def run(csv_data):
     detector.start()
 
     captureFile = cv2.VideoCapture(input_file)
-    window = cv2.namedWindow('Processed Frame',cv2.WINDOW_NORMAL)
-    cv2.resizeWindow('Processed Frame',frame_width, frame_height)
+    window = cv2.namedWindow('Processed Frame', cv2.WINDOW_NORMAL)
+    cv2.resizeWindow('Processed Frame', frame_width, frame_height)
 
     if not args.video:
         captureFile.set(cv2.CAP_PROP_FRAME_HEIGHT, frame_height)
         captureFile.set(cv2.CAP_PROP_FRAME_WIDTH, frame_width)
         #If cv2 silently fails, default to 1280 x 720 instead of 640 x 480
         if captureFile.get(3) != frame_width or captureFile.get(4) != frame_height:
-            print("Unsupported resolution, defaulting to 1280 x 720")
+            print(f"{frame_width} x {frame_height} is an unsupported resolution, defaulting to 1280 x 720")
+            captureFile.set(cv2.CAP_PROP_FRAME_HEIGHT, DEFAULT_FRAME_HEIGHT)
+            captureFile.set(cv2.CAP_PROP_FRAME_WIDTH, DEFAULT_FRAME_WIDTH)
             frame_width = DEFAULT_FRAME_WIDTH
             frame_height = DEFAULT_FRAME_HEIGHT
+            cv2.resizeWindow('Processed Frame',DEFAULT_FRAME_WIDTH, DEFAULT_FRAME_HEIGHT)
         file_width = frame_width
         file_height = frame_height
 
     else:
         file_width = int(captureFile.get(3))
         file_height = int(captureFile.get(4))
-        cv2.resizeWindow('Processed Frame',file_width,file_height)
+        #cv2.resizeWindow('Processed Frame', file_width,file_height)
 
     if output_file is not None:
        out = cv2.VideoWriter(output_file, cv2.VideoWriter_fourcc('M', 'J', 'P', 'G'), 10, (file_width, file_height))
@@ -466,16 +473,15 @@ def run(csv_data):
                 timestamp = (time.time() - start_time) * 1000.0
             else:
                 timestamp = int(captureFile.get(cv2.CAP_PROP_POS_MSEC))
-            time_metrics_dict['timestamp'].put(timestamp)
+            time_metrics_dict['timestamp'] = timestamp #.put(timestamp)
             afframe = af.Frame(width, height, frame, af.ColorFormat.bgr, int(timestamp))
             count += 1
             try:
-
                 detector.process(afframe)
 
             except Exception as exp:
                 print(exp)
-            write_metrics_to_csv_data_list(csv_data, round(timestamp,0))
+            write_metrics_to_csv_data_list(csv_data, round(timestamp, 0))
 
             if len(num_faces) > 0 and not check_bounding_box_outside(width, height):
                 draw_bounding_box(frame)
@@ -510,11 +516,11 @@ def run(csv_data):
         write_csv_data_to_file(csv_data, csv_file)
 
 
-"""Clears the dictionary values
-   """
-
 
 def clear_all_dictionaries():
+    """
+    Clears the dictionary values
+    """
     bounding_box_dict.clear()
     emotions_dict.clear()
     expressions_dict.clear()
@@ -522,21 +528,20 @@ def clear_all_dictionaries():
     mood_dict.clear()
 
 
-"""Place logo on the screen
-
-   Parameters
-   ----------
-   frame: affvisionpy.Frame
-       Frame to place the logo on
-   width: int
-       width of the frame
-   height: int
-       height of the frame
-
-   """
-
 
 def draw_affectiva_logo(frame, width, height):
+    """
+    Place logo on the screen
+
+        Parameters
+        ----------
+        frame: affvisionpy.Frame
+           Frame to place the logo on
+        width: int
+           width of the frame
+        height: int
+           height of the frame
+    """
     logo = cv2.imread("Final logo - RGB Magenta.png")
     logo_width = int(width / 3)
     logo_height = int(height / 10)
@@ -552,22 +557,22 @@ def draw_affectiva_logo(frame, width, height):
         frame[y1:y2, x1:x2, c] = color + beta
 
 
-"""Check if bounding box values are going outside the screen in case of face going outside
 
-   Parameters
-   ----------
-   width: int
-       width of the frame
-   height: int
-       height of the frame
+def check_bounding_box_outside(width, height):
+    """
+    Check if bounding box values are going outside the screen in case of face going outside
+
+        Parameters
+        ----------
+        width: int
+           width of the frame
+        height: int
+           height of the frame
 
     Returns
     -------
     boolean: indicating if the bounding box is outside the frame or not
-   """
-
-
-def check_bounding_box_outside(width, height):
+    """
     for fid in bounding_box_dict.keys():
         x1, y1, x2, y2 = get_bounding_box_points(fid)
         if x1 < 0 or x2 > width or y1 < 0 or y2 > height:
@@ -575,19 +580,19 @@ def check_bounding_box_outside(width, height):
         return False
 
 
-"""Write metrics per frame to a list
-
-   Parameters
-   ----------
-   csv_data:
-      list of per frame values to write to
-   timestamp: int
-       timestamp of each frame
-
-   """
-
 
 def write_metrics_to_csv_data_list(csv_data, timestamp):
+    """
+    Write metrics per frame to a list
+
+        Parameters
+        ----------
+        csv_data:
+          list of per frame values to write to
+        timestamp: int
+           timestamp of each frame
+
+    """
     global header_row
     current_frame_data = {}
     if not measurements_dict.keys():
@@ -601,8 +606,11 @@ def write_metrics_to_csv_data_list(csv_data, timestamp):
         for fid in measurements_dict.keys():
             current_frame_data["TimeStamp"] = timestamp
             current_frame_data["faceId"] = fid
-            x0,y0,x1,y1 = get_bounding_box_points(fid)
-            current_frame_data["upperLeftX"],current_frame_data["upperLeftY"], current_frame_data["lowerRightX"],current_frame_data["lowerRightY"] = x0,y0,x1,y1
+            upperLeftX, upperLeftY, lowerRightX, lowerRightY = get_bounding_box_points(fid)
+            current_frame_data["upperLeftX"] = upperLeftX
+            current_frame_data["upperLeftY"] = upperLeftY
+            current_frame_data["lowerRightX"] = lowerRightX
+            current_frame_data["lowerRightY"] = lowerRightY
             for key,val in measurements_dict[fid].items():
                 current_frame_data[str(key).split('.')[1]] = round(val,4)
             for key,val in emotions_dict[fid].items():
@@ -616,18 +624,18 @@ def write_metrics_to_csv_data_list(csv_data, timestamp):
             csv_data.append(current_frame_data)
 
 
-"""Make the options for command line
-
-   Returns
-   -------
-   args: argparse object of the command line
-   """
-
 
 def parse_command_line():
+    """
+    Make the options for command line
+
+    Returns
+    -------
+    args: argparse object of the command line
+    """
     parser = argparse.ArgumentParser(description="Sample code for demoing affdexface on webcam or a saved video file.\n \
-    By default, the program will run with the camera parameter displaying frames of size 1280 x 720.\n \
-    Individual frames will be saved in opvideo directory. If video file supplied, output files will be saved with the same name by default. ")
+        By default, the program will run with the camera parameter displaying frames of size 1280 x 720.\n \
+        A CSV file will also be written by default with the filename 'default.csv'. ")
     parser.add_argument("-d", "--data", dest="data", required=True, help="path to directory containing the models")
     parser.add_argument("-i", "--input", dest="video", required=False,
                         help="path to input video file")
@@ -637,32 +645,31 @@ def parse_command_line():
                         help="enable this parameter take input from the webcam and provide a camera id for the webcam")
     parser.add_argument("-o", "--output", dest="output", required=False,
                         help="name of the output video file")
-    parser.add_argument("-f", "--file", dest="file", required=False, default="default",
-                        help="name of the output csv file")
-    parser.add_argument("-r", "--resolution",dest='res',metavar=('width','height'),nargs=2,default=[1280,720], help="resolution in pixels (2-values): width height")
+    parser.add_argument("-f", "--file", dest="file", required=False, default=DEFAULT_FILE_NAME,
+                        help="name of the output CSV file")
+    parser.add_argument("-r", "--resolution", dest='res', metavar=('width', 'height'), nargs=2, default=[1280, 720], help="resolution in pixels (2-values): width height")
     args = parser.parse_args()
     return args
 
 
-"""Place logo on the screen
-
-   Parameters
-   ----------
-   csv_data: list
-       list to write the data from
-    csv_file: list
-       file to be written to
-
-   """
-
 
 def write_csv_data_to_file(csv_data, csv_file):
+    """
+    Place logo on the screen
+
+        Parameters
+        ----------
+        csv_data: list
+           list to write the data from
+        csv_file: list
+           file to be written to
+    """
     global header_row
     if ".csv" not in csv_file:
         csv_file = csv_file + ".csv"
     with open(csv_file, 'w') as c_file:
         keys = csv_data[0].keys()
-        writer = csv.DictWriter(c_file,fieldnames=header_row)
+        writer = csv.DictWriter(c_file, fieldnames=header_row)
         writer.writeheader()
         for row in csv_data:
             writer.writerow(row)

--- a/python-sdk-samples/affvisionpy-sample.py
+++ b/python-sdk-samples/affvisionpy-sample.py
@@ -43,6 +43,7 @@ emotions_dict = defaultdict()
 bounding_box_dict = defaultdict()
 mood_dict = defaultdict()
 time_metrics_dict = defaultdict()
+faceId_set = set()
 
 
 
@@ -67,6 +68,7 @@ class Listener(af.ImageListener):
         global num_faces
         num_faces = faces
         for fid, face in faces.items():
+            faceId_set.update(faces.keys())
             measurements_dict[face.get_id()] = defaultdict()
             expressions_dict[face.get_id()] = defaultdict()
             emotions_dict[face.get_id()] = defaultdict()
@@ -595,19 +597,15 @@ def write_metrics_to_csv_data_list(csv_data, timestamp):
 
     """
     global header_row
-    current_frame_data = {}
-    if not measurements_dict.keys():
-        for field in header_row:
-            if field == "TimeStamp":
-                current_frame_data[field] = timestamp
-            else:
+    for fid in faceId_set:
+        current_frame_data = {}
+        current_frame_data["TimeStamp"] = timestamp
+        current_frame_data["faceId"] = fid
+        if fid not in measurements_dict.keys():
+            for field in header_row[2:]:
                 current_frame_data[field] = NOT_A_NUMBER
-        csv_data.append(current_frame_data)
-    else:
-        for fid in measurements_dict.keys():
-            current_frame_data = {}
-            current_frame_data["TimeStamp"] = timestamp
-            current_frame_data["faceId"] = fid
+            csv_data.append(current_frame_data)
+        else:
             upperLeftX, upperLeftY, lowerRightX, lowerRightY = get_bounding_box_points(fid)
             current_frame_data["upperLeftX"] = upperLeftX
             current_frame_data["upperLeftY"] = upperLeftY


### PR DESCRIPTION
- updated documentation to reflect default behavior of writing csv both for webcam and video options. 

- modified text on frames to have black outlines (measurements have been left the same for reference, emotion metrics and expression metrics are in different fonts for comparison for feedback on which font options people think work best. ). Size of text also increased slightly. 

-  cli arguments for resolution changed to match frame-detector. Default resolution of 1280 x 720.  

- help documentation updated 

- printing of metrics to console changed to generally match frame-detector (differences are that frame-detector outputs number of faces it seems, affvisionpy-sample prints out frame number).
