### PR TITLE
Update affvisionpy-sample.py

### DIFF
--- a/python-sdk-samples/affvisionpy-sample.py
+++ b/python-sdk-samples/affvisionpy-sample.py
@@ -541,7 +541,7 @@ def draw_affectiva_logo(frame, width, height):
         height: int
            height of the frame
     """
-    logo = cv2.imread("Final logo - RGB Magenta.png")
+    logo = cv2.imread(os.path.dirname(os.path.abspath(__file__))+"/Final logo - RGB Magenta.png")
     logo_width = int(width / 3)
     logo_height = int(height / 10)
     logo = cv2.resize(logo, (logo_width, logo_height))


### PR DESCRIPTION
Fix error that occurs when running sample outside of the directory that contains the logo