### PR TITLE
Sdk 3841

### DIFF
--- a/affvisionpy_sample.py
+++ b/affvisionpy_sample.py
@@ -137,7 +137,6 @@ def run(csv_data):
 
     capture_file.release()
     cv2.destroyAllWindows()
-    detector.stop()
 
     # If video file is provided as an input
     if not isinstance(input_file, int):
@@ -193,6 +192,7 @@ def process_face_input(detector, capture_file, input_file, start_time, output_fi
                     print(exp)
 
                 listener.mutex.acquire()
+
                 faces = listener.faces.copy()
                 measurements_dict = listener.measurements_dict.copy()
                 expressions_dict = listener.expressions_dict.copy()
@@ -240,6 +240,8 @@ def process_face_input(detector, capture_file, input_file, start_time, output_fi
                       (last_timestamp, curr_timestamp))
         else:
             break
+
+    detector.stop()
 
 def process_object_input(detector, capture_file, input_file, start_time, output_file, out, logo, args):
     count = 0
@@ -320,6 +322,8 @@ def process_object_input(detector, capture_file, input_file, start_time, output_
         else:
             break
 
+    detector.stop()
+
 def process_occupant_input(detector, capture_file, input_file, start_time, output_file, out, logo, args):
     count = 0
     last_timestamp = 0
@@ -396,6 +400,8 @@ def process_occupant_input(detector, capture_file, input_file, start_time, outpu
         else:
             break
 
+    detector.stop()
+
 def process_body_input(detector, capture_file, input_file, start_time, output_file, out, logo, args):
     count = 0
     last_timestamp = 0
@@ -459,6 +465,8 @@ def process_body_input(detector, capture_file, input_file, start_time, output_fi
                     last_timestamp, curr_timestamp))
         else:
             break
+
+    detector.stop()
 
 def write_face_metrics_to_csv_data_list(csv_data, timestamp, listener_metrics):
     """

--- a/affvisionpy_sample.py
+++ b/affvisionpy_sample.py
@@ -254,7 +254,6 @@ def process_object_input(detector, capture_file, input_file, start_time, output_
     listener = ObjectListener(OBJECT_CALLBACK_INTERVAL)
     detector.set_object_listener(listener)
 
-    print("Setting up object detection")
     detector.start()
 
     while capture_file.isOpened():
@@ -334,7 +333,6 @@ def process_occupant_input(detector, capture_file, input_file, start_time, outpu
     listener = OccupantListener(OCCUPANT_CALLBACK_INTERVAL)
     detector.set_occupant_listener(listener)
 
-    print("Setting up occupant detection")
     detector.start()
 
     while capture_file.isOpened():
@@ -412,7 +410,6 @@ def process_body_input(detector, capture_file, input_file, start_time, output_fi
     listener = BodyListener(BODY_CALLBACK_INTERVAL)
     detector.set_body_listener(listener)
 
-    print("Setting up body detection")
     detector.start()
 
     while capture_file.isOpened():
@@ -743,7 +740,6 @@ def get_command_line_parameters(parser, args):
         parser.print_help()
         sys.exit(1)
     elif not (is_occupant or is_object or is_body):
-        print("Setting up face detection\n")
         show_faces = True
 
     global header_row


### PR DESCRIPTION
fixes SDK-3841 (crash on exit when using FrameDetector)

Previously the detector was being stopped in run(), AFTER the appropriate process_XXX_input method was called.  However, when using FrameDetector, this caused intermittent crashes at shutdown time because the listener objects are defined in those process_XXX_input methods, and therefore they go out of scope when those methods return.  Since the background processing thread in the SDK may still be processing frames at that point and invoking the listeners,  that's bad.

The fix is to move the stop() call into the process_XXX_input methods so that background processing finishes before the listeners go out of scope.