### PR TITLE
better handling of LD_LIBRARY_PATH requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ This script demonstrates how to use Affectiva's affvisionpy module to process fr
 
 2. **cd** into the directory having the requirements.txt file and run **pip3 install -r requirements.txt**
 
+## Setting LD_LIBRARY_PATH
+To use the affvisionpy module, you must set and export the LD_LIBRARY_PATH environment variable to the  "lib" subfolder
+under the affvisionpy installation folder, e.g. 
+        
+        export LD_LIBRARY_PATH=<python root>/lib/<python version>/site-packages/affvisionpy/lib`.
 
 ## Usage ##
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,13 @@ This script demonstrates how to use Affectiva's affvisionpy module to process fr
 2. **cd** into the directory having the requirements.txt file and run **pip3 install -r requirements.txt**
 
 ## Setting LD_LIBRARY_PATH
-To use the affvisionpy module, you must set and export the LD_LIBRARY_PATH environment variable to the  "lib" subfolder
-under the affvisionpy installation folder, e.g. 
-        
-        export LD_LIBRARY_PATH=<python root>/lib/<python version>/site-packages/affvisionpy/lib`.
+To use the "identity" or "appearances" features of the affvisionpy module, you must export the LD_LIBRARY_PATH
+environment variable with a value that refers to the "lib" subfolder under the affvisionpy installation directory.
+
+This installation directory can vary depending on your python configuration, but if you execute the following
+command in a bash shell, it will set the environment value for you:
+
+    export LD_LIBRARY_PATH=$(python3 -c "exec(\"import affvisionpy,os\nprint(os.path.dirname(os.path.realpath(affvisionpy.__file__)) + '/lib')\")")
 
 ## Usage ##
 

--- a/affvisionpy_sample.py
+++ b/affvisionpy_sample.py
@@ -5,17 +5,6 @@ import sys
 import os
 import time
 import csv
-from collections import defaultdict
-
-# Before we import affvisionpy, check to see if LD_LIBRARY_PATH is set to a value that looks appropriate
-# If it's not set, importing affvisionpy will fail, and the error isn't that helpful.
-ld_library_path = os.environ.get("LD_LIBRARY_PATH")
-if (not ld_library_path or not os.path.isfile(ld_library_path + "/libaffectiva-vision.so")):
-    print("You must set and export the LD_LIBRARY_PATH environment variable to the \"lib\" subfolder under the "
-          "affvisionpy installation folder, e.g. <python root>/lib/<python version>/site-packages/affvisionpy/lib")
-    exit(1)
-
-
 import affvisionpy as af
 import cv2
 
@@ -55,8 +44,7 @@ HEADER_ROW_OCCUPANTS = ['TimeStamp', 'occupantId', 'bodyId', 'confidence', 'regi
 
 HEADER_ROW_BODIES = ['TimeStamp', 'bodyId']
 header_row = []
-
-identity_names_dict = defaultdict()
+identity_names_dict = {}
 
 
 def get_video_fps(input_file, fps):
@@ -758,6 +746,16 @@ def get_command_line_parameters(parser, args):
 
     global header_row
     if show_faces:
+
+        # If we're processing faces, check to see if LD_LIBRARY_PATH is set to a value that looks appropriate.
+        # If it's not set, enabling the identity or appearances feature on the detector will will fail, and the error
+        # isn't that helpful.
+        ld_library_path = os.environ.get("LD_LIBRARY_PATH")
+        if (not ld_library_path or not os.path.isfile(ld_library_path + "/libaffectiva-vision.so")):
+            print("When enabling face-based features, you must export the LD_LIBRARY_PATH environment variable as shown below:")
+            print("    export LD_LIBRARY_PATH=" + os.path.dirname(os.path.realpath(af.__file__)) + "/lib")
+            exit(1)
+
         header_row = HEADER_ROW_FACES
         if args.show_identity:
             global identity_names_dict

--- a/affvisionpy_sample.py
+++ b/affvisionpy_sample.py
@@ -1,10 +1,20 @@
 # !/usr/bin/env python3
+
 import argparse
 import sys
 import os
 import time
 import csv
 from collections import defaultdict
+
+# Before we import affvisionpy, check to see if LD_LIBRARY_PATH is set to a value that looks appropriate
+# If it's not set, importing affvisionpy will fail, and the error isn't that helpful.
+ld_library_path = os.environ.get("LD_LIBRARY_PATH")
+if (not ld_library_path or not os.path.isfile(ld_library_path + "/libaffectiva-vision.so")):
+    print("You must set and export the LD_LIBRARY_PATH environment variable to the \"lib\" subfolder under the "
+          "affvisionpy installation folder, e.g. <python root>/lib/<python version>/site-packages/affvisionpy/lib")
+    exit(1)
+
 
 import affvisionpy as af
 import cv2


### PR DESCRIPTION
Add note to readme.md file explaining that LD_LIBRARY_PATH must be set

Add a check at the top of the python sample to confirm that LD_LIBRARY_PATH is set to a valid location.

fixes SDK-3800