### PR TITLE
SDK-3855 - update display id and write to csv correctly

### DIFF
--- a/affvisionpy_sample.py
+++ b/affvisionpy_sample.py
@@ -41,7 +41,7 @@ HEADER_ROW_FACES = ['TimeStamp', 'faceId', 'upperLeftX', 'upperLeftY', 'lowerRig
 HEADER_ROW_OBJECTS = ['TimeStamp', 'objectId', 'confidence', 'upperLeftX', 'upperLeftY', 'lowerRightX', 'lowerRightY',
                       'ObjectType']
 
-HEADER_ROW_OCCUPANTS = ['TimeStamp', 'occupantId', 'bodyId', 'confidence', 'regionId', 'regionType', 'upperLeftX', 'upperLeftY', 'lowerRightX', 'lowerRightY']
+HEADER_ROW_OCCUPANTS = ['TimeStamp', 'occupantId', 'bodyId', 'faceId',  'confidence', 'regionId', 'regionType', 'upperLeftX', 'upperLeftY', 'lowerRightX', 'lowerRightY']
 
 HEADER_ROW_BODIES = ['TimeStamp', 'bodyId']
 header_row = []
@@ -370,6 +370,7 @@ def process_occupant_input(detector, capture_file, input_file, start_time, outpu
                 region_type_dict = listener.regionType.copy()
                 body_id_dict = listener.bodyId.copy()
                 body_points_dict = listener.bodyPoints.copy()
+                face_id_dict = listener.faceId.copy()
                 listener.mutex.release()
 
                 listener_metrics = {
@@ -379,7 +380,8 @@ def process_occupant_input(detector, capture_file, input_file, start_time, outpu
                     "region": region_dict,
                     "region_type": region_type_dict,
                     "body_id": body_id_dict,
-                    "body_points": body_points_dict
+                    "body_points": body_points_dict,
+                    "face_id": face_id_dict
                 }
 
                 write_occupant_metrics_to_csv_data_list(csv_data, round(curr_timestamp, 0), listener_metrics)
@@ -578,6 +580,7 @@ def write_occupant_metrics_to_csv_data_list(csv_data, timestamp, listener_metric
             current_frame_data["regionId"] = listener_metrics["region_id"][occ_id]
             current_frame_data["regionType"] = listener_metrics["region_type"][occ_id]
             current_frame_data["bodyId"] = listener_metrics["body_id"][occ_id]
+            current_frame_data["faceId"] = listener_metrics["face_id"][occ_id]
             csv_data.append(current_frame_data)
             current_frame_data = {}
     else:

--- a/display_metrics.py
+++ b/display_metrics.py
@@ -247,6 +247,14 @@ def draw_occupants(frame, listener_metrics):
             upper_left_y -= LINE_HEIGHT
             display_top_metrics("occupant_id", occid, upper_left_x, upper_left_y, frame)
             upper_left_y -= LINE_HEIGHT
+            face_id = listener_metrics["face_id"][occid]
+            face_id = 'n/a' if face_id == 'nan' else face_id
+            display_top_metrics("face_id", face_id, upper_left_x, upper_left_y, frame)
+            upper_left_y -= LINE_HEIGHT
+            body_id = listener_metrics["body_id"][occid]
+            body_id = 'n/a' if body_id == 'nan' else body_id
+            display_top_metrics("body_id", body_id, upper_left_x, upper_left_y, frame)
+            upper_left_y -= LINE_HEIGHT
             draw_bodies(frame, listener_metrics)
 
 def draw_bodies(frame, listener_metrics):

--- a/occupant_listener.py
+++ b/occupant_listener.py
@@ -25,6 +25,8 @@ class OccupantListener(af.OccupantListener):
         self.regionType = defaultdict()
         self.bodyId = defaultdict()
         self.bodyPoints = defaultdict()
+        self.faceId = defaultdict()
+
 
     def results_updated(self, occupants, frame):
         timestamp = frame.timestamp()
@@ -52,17 +54,21 @@ class OccupantListener(af.OccupantListener):
             self.regionType[occid] = occ.get_matched_seat().cabin_region.type.name
             if self.regionId[occid] != -1:
                 self.region[occid] = occ.get_matched_seat().cabin_region.vertices
-            # TODO: research the bug where we are not able to access object directly and gives "munmap_chunk(): invalid pointer"
-            # body_occ = occ.get_body()
-            # if body_occ is not None:
-            #     self.bodyId[occid] = body_occ.get_body_id()
-            #     b_pts = body_occ.get_body_points()
-            #     body_points = {}
-            #     for b_pt, pt in b_pts.items():
-            #         body_points[b_pt.name] = [int(pt.x), int(pt.y)]
-            #     self.bodyPoints[occid] = body_points
-            # else:
-            self.bodyId[occid] = "nan"
+            body_occ = occ.get_body()
+            if body_occ is not None:
+                self.bodyId[occid] = body_occ.get_id()
+                b_pts = body_occ.get_body_points()
+                body_points = {}
+                for b_pt, pt in b_pts.items():
+                    body_points[b_pt.name] = [int(pt.x), int(pt.y)]
+                self.bodyPoints[occid] = body_points
+            else:
+                self.bodyId[occid] = "nan"
+            face_occ = occ.get_face()
+            if face_occ is not None:
+                self.faceId[occid] = face_occ.get_id()
+            else:
+                self.faceId[occid] = "nan"
             self.confidence[occid] = occ.get_matched_seat().match_confidence
         self.mutex.release()
 
@@ -80,3 +86,4 @@ class OccupantListener(af.OccupantListener):
         self.regionType.clear()
         self.bodyId.clear()
         self.bodyPoints.clear()
+        self.faceId.clear()


### PR DESCRIPTION
- id's related to occupant will be as shown 'n/a' when not available
- face_id is now written to csv when --occupant is enabled